### PR TITLE
fix: cannot set default timeout == None

### DIFF
--- a/src/cache3/validate.py
+++ b/src/cache3/validate.py
@@ -35,6 +35,9 @@ class NumberValidate(Validator):
         self.maxvalue: Number = maxvalue
 
     def validate(self, value) -> NoReturn:
+        
+        if value is None:
+            return
 
         if not isinstance(value, (int, float)):
             raise TypeError(f'Expected {value!r} to be an int or float')


### PR DESCRIPTION
I want to create a cache without a timeout, but this throws an exception。

`DiskCache(timeout=None)`